### PR TITLE
Add tests.wordpress-develop.dev site

### DIFF
--- a/provision/vvv-hosts
+++ b/provision/vvv-hosts
@@ -1,3 +1,4 @@
 # WP Develop
 src.wordpress-develop.dev
 build.wordpress-develop.dev
+tests.wordpress-develop.dev

--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -32,12 +32,12 @@ if [[ ! -d "${VVV_PATH_TO_SITE}/public_html" ]]; then
   cd ${VVV_PATH_TO_SITE}/public_html/src/
   echo "Creating wp-config.php for src.wordpress-develop.dev and build.wordpress-develop.dev."
   noroot wp core config --dbname=wordpress_develop --dbuser=wp --dbpass=wp --quiet --extra-php <<PHP
-// Match any requests made via xip.io.
-if ( isset( \$_SERVER['HTTP_HOST'] ) && preg_match('/^(src|build)(.wordpress-develop.)\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}(.xip.io)\z/', \$_SERVER['HTTP_HOST'] ) ) {
+// Match any requests made via xip.io or tests.wordpress-develop.dev.
+if ( isset( \$_SERVER['HTTP_HOST'] ) && preg_match('/^tests\.wordpress-develop\.dev$|^(src|build)(\.wordpress-develop\.)\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}(.xip.io)\z/', \$_SERVER['HTTP_HOST'] ) ) {
     define( 'WP_HOME', 'http://' . \$_SERVER['HTTP_HOST'] );
     define( 'WP_SITEURL', 'http://' . \$_SERVER['HTTP_HOST'] );
 } else if ( 'build' === basename( dirname( __FILE__ ) ) ) {
-// Allow (src|build).wordpress-develop.dev to share the same Database
+    // Allow (src|build).wordpress-develop.dev to share the same Database
     define( 'WP_HOME', 'http://build.wordpress-develop.dev' );
     define( 'WP_SITEURL', 'http://build.wordpress-develop.dev' );
 }
@@ -45,9 +45,16 @@ if ( isset( \$_SERVER['HTTP_HOST'] ) && preg_match('/^(src|build)(.wordpress-dev
 define( 'WP_DEBUG', true );
 PHP
 
+  # Route WordPress to the tests database when requested.
+  replace "'DB_NAME'," "'DB_NAME', isset( \$_SERVER['HTTP_HOST'] ) && 0 === strpos( \$_SERVER['HTTP_HOST'], 'tests.' ) ? 'wordpress_unit_tests' : " -- wp-config.php
+  replace '$table_prefix =' "\$table_prefix = isset( \$_SERVER['HTTP_HOST'] ) && 0 === strpos( \$_SERVER['HTTP_HOST'], 'tests.' ) ? 'wptests_' : " -- wp-config.php
+
   echo "Installing src.wordpress-develop.dev."
   noroot wp core install --url=src.wordpress-develop.dev --quiet --title="WordPress Develop" --admin_name=admin --admin_email="admin@local.dev" --admin_password="password"
   cp /srv/config/wordpress-config/wp-tests-config.php ${VVV_PATH_TO_SITE}/public_html/
+
+  replace "'example.org'" "'tests.wordpress-develop.dev'" -- ${VVV_PATH_TO_SITE}/public_html/wp-tests-config.php
+
   cd ${VVV_PATH_TO_SITE}/public_html/
 
 else

--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -36,10 +36,14 @@ if [[ ! -d "${VVV_PATH_TO_SITE}/public_html" ]]; then
 if ( isset( \$_SERVER['HTTP_HOST'] ) && preg_match('/^tests\.wordpress-develop\.dev$|^(src|build)(\.wordpress-develop\.)\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}(.xip.io)\z/', \$_SERVER['HTTP_HOST'] ) ) {
     define( 'WP_HOME', 'http://' . \$_SERVER['HTTP_HOST'] );
     define( 'WP_SITEURL', 'http://' . \$_SERVER['HTTP_HOST'] );
+    define( 'WP_CACHE_KEY_SALT', \$_SERVER['HTTP_HOST'] );
 } else if ( 'build' === basename( dirname( __FILE__ ) ) ) {
     // Allow (src|build).wordpress-develop.dev to share the same Database
     define( 'WP_HOME', 'http://build.wordpress-develop.dev' );
     define( 'WP_SITEURL', 'http://build.wordpress-develop.dev' );
+    define( 'WP_CACHE_KEY_SALT', 'build.wordpress-develop.dev' );
+} else {
+    define( 'WP_CACHE_KEY_SALT', 'src.wordpress-develop.dev' );
 }
 
 define( 'WP_DEBUG', true );

--- a/provision/vvv-nginx.conf
+++ b/provision/vvv-nginx.conf
@@ -8,7 +8,7 @@
 server {
     listen       80;
     listen       443 ssl;
-    server_name  src.wordpress-develop.dev *.src.wordpress-develop.dev ~^src\.wordpress-develop\.\d+\.\d+\.\d+\.\d+\.xip\.io$;
+    server_name  src.wordpress-develop.dev *.src.wordpress-develop.dev ~^src\.wordpress-develop\.\d+\.\d+\.\d+\.\d+\.xip\.io$ tests.wordpress-develop.dev;
     root         {vvv_path_to_site}/public_html/src;
 
     error_log    {vvv_path_to_site}/log/src.error.log;


### PR DESCRIPTION
This is an exploration into making available the `tests.wordpress-develop.dev` domain as an alias for the same Nginx docroot that serves `src.wordpress-develop.dev`, but which loads from the database used for unit testing instead of the normal database that the dev site reads from.

The reason for making the WordPress tests database available on its own site is for the sake of allowing for automated acceptance tests (such as via Codeception or Behat) to be run on this separate environment. See [#34693](https://core.trac.wordpress.org/ticket/34693). If the WordPress dev environment in VVV has a known URL at which a test install is accessible, then the test runners will know where to direct the automated browsers.

WP-CLI can be routed to the test site by means of supplying the `--url`. For example, to reset the database for the tests environment:

```bash
wp --url=http://tests.wordpress-develop.dev db reset
```

Though naturally the DB is reset with each unit test as well.