### PR TITLE
Test tld

### DIFF
--- a/bin/develop_git
+++ b/bin/develop_git
@@ -26,7 +26,7 @@ if [[ -e .git ]]; then
 	exit 1
 fi
 
-echo "Converting src.wordpress-develop.dev from SVN to GIT"
+echo "Converting src.wordpress-develop.test from SVN to GIT"
 
 echo "Rename .svn to .svn-backup"
 mv .svn .svn-backup

--- a/provision/vvv-hosts
+++ b/provision/vvv-hosts
@@ -1,3 +1,5 @@
 # WP Develop
+src.wordpress-develop.test
+build.wordpress-develop.test
 src.wordpress-develop.dev
 build.wordpress-develop.dev

--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -20,10 +20,10 @@ if [[ ! -d "${VVV_PATH_TO_SITE}/public_html" ]]; then
 
   cd /tmp/wordpress-develop/src/
 
-  echo "Installing local npm packages for src.wordpress-develop.dev, this may take several minutes."
+  echo "Installing local npm packages for src.wordpress-develop.test, this may take several minutes."
   noroot npm install
 
-  echo "Initializing grunt and creating build.wordpress-develop.dev, this may take several minutes."
+  echo "Initializing grunt and creating build.wordpress-develop.test, this may take several minutes."
   noroot grunt
 
   echo "Moving WordPress develop to a shared directory, ${VVV_PATH_TO_SITE}/public_html"

--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -30,23 +30,23 @@ if [[ ! -d "${VVV_PATH_TO_SITE}/public_html" ]]; then
   mv /tmp/wordpress-develop ${VVV_PATH_TO_SITE}/public_html
 
   cd ${VVV_PATH_TO_SITE}/public_html/src/
-  echo "Creating wp-config.php for src.wordpress-develop.dev and build.wordpress-develop.dev."
+  echo "Creating wp-config.php for src.wordpress-develop.test and build.wordpress-develop.test."
   noroot wp core config --dbname=wordpress_develop --dbuser=wp --dbpass=wp --quiet --extra-php <<PHP
 // Match any requests made via xip.io.
 if ( isset( \$_SERVER['HTTP_HOST'] ) && preg_match('/^(src|build)(.wordpress-develop.)\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}(.xip.io)\z/', \$_SERVER['HTTP_HOST'] ) ) {
     define( 'WP_HOME', 'http://' . \$_SERVER['HTTP_HOST'] );
     define( 'WP_SITEURL', 'http://' . \$_SERVER['HTTP_HOST'] );
 } else if ( 'build' === basename( dirname( __FILE__ ) ) ) {
-// Allow (src|build).wordpress-develop.dev to share the same Database
-    define( 'WP_HOME', 'http://build.wordpress-develop.dev' );
-    define( 'WP_SITEURL', 'http://build.wordpress-develop.dev' );
+// Allow (src|build).wordpress-develop.test to share the same Database
+    define( 'WP_HOME', 'http://build.wordpress-develop.test' );
+    define( 'WP_SITEURL', 'http://build.wordpress-develop.test' );
 }
 
 define( 'WP_DEBUG', true );
 PHP
 
-  echo "Installing src.wordpress-develop.dev."
-  noroot wp core install --url=src.wordpress-develop.dev --quiet --title="WordPress Develop" --admin_name=admin --admin_email="admin@local.dev" --admin_password="password"
+  echo "Installing src.wordpress-develop.test."
+  noroot wp core install --url=src.wordpress-develop.test --quiet --title="WordPress Develop" --admin_name=admin --admin_email="admin@local.test" --admin_password="password"
   cp /srv/config/wordpress-config/wp-tests-config.php ${VVV_PATH_TO_SITE}/public_html/
   cd ${VVV_PATH_TO_SITE}/public_html/
 

--- a/provision/vvv-nginx.conf
+++ b/provision/vvv-nginx.conf
@@ -8,7 +8,7 @@
 server {
     listen       80;
     listen       443 ssl;
-    server_name  src.wordpress-develop.dev *.src.wordpress-develop.dev ~^src\.wordpress-develop\.\d+\.\d+\.\d+\.\d+\.xip\.io$;
+    server_name  src.wordpress-develop.test *.src.wordpress-develop.test src.wordpress-develop.dev *.src.wordpress-develop.dev ~^src\.wordpress-develop\.\d+\.\d+\.\d+\.\d+\.xip\.io$;
     root         {vvv_path_to_site}/public_html/src;
 
     error_log    {vvv_path_to_site}/log/src.error.log;
@@ -29,7 +29,7 @@ server {
 server {
     listen       80;
     listen       443 ssl;
-    server_name  build.wordpress-develop.dev *.build.wordpress-develop.dev ~^build\.wordpress-develop\.\d+\.\d+\.\d+\.\d+\.xip\.io$;
+    server_name  build.wordpress-develop.test *.build.wordpress-develop.test build.wordpress-develop.dev *.build.wordpress-develop.dev ~^build\.wordpress-develop\.\d+\.\d+\.\d+\.\d+\.xip\.io$;
     root         {vvv_path_to_site}/public_html/build;
 
     error_log    {vvv_path_to_site}/log/build.error.log;


### PR DESCRIPTION
Changes the src/build wp provisioner to use .test by default, don't forget to change the repo tagline to use .test too!

Should help with https://github.com/Varying-Vagrant-Vagrants/VVV/issues/583