### PR TITLE
After creating wp-config.php, copy from src to build folder

### DIFF
--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -44,6 +44,9 @@ if ( isset( \$_SERVER['HTTP_HOST'] ) && preg_match('/^(src|build)(.wordpress-dev
 
 define( 'WP_DEBUG', true );
 PHP
+  
+  // Copy over the config file from src to build, since grunt already ran.
+  cp /srv/www/wordpress-develop/public_html/src/wp-config.php /srv/www/wordpress-develop/public_html/build/
 
   echo "Installing src.wordpress-develop.test."
   noroot wp core install --url=src.wordpress-develop.test --quiet --title="WordPress Develop" --admin_name=admin --admin_email="admin@local.test" --admin_password="password"


### PR DESCRIPTION
### Changes

* The current build process runs grunt, and then later creates a `wp-config.php` file in the `src` folder. This PR copies that file into the `build` folder. Another option would be to run grunt after the file is created, however this seemed like a simpler change.

### Issue

After installing VVV and running `vagrant up`, going to `build.wordpress-develop.test` brings me to the install page because the wp-config.php file is missing from the build folder.

### Expected behavior
I should be able to run WordPress from `build.wordpress-develop.test` after an initial install.

### Actual behavior
WordPress prompts for an install.